### PR TITLE
Make ForEachRemover handle non-void return values

### DIFF
--- a/src/main/java/net/gudenau/minecraft/fps/transformer/ForEachRemover.java
+++ b/src/main/java/net/gudenau/minecraft/fps/transformer/ForEachRemover.java
@@ -160,6 +160,16 @@ public class ForEachRemover implements Transformer{
                     targetOpcode == INVOKEINTERFACE
                 ));
                 
+                // Return value of a foreach handle is not always void
+                switch (Type.getMethodType(targetHandle.getDesc()).getReturnType().getSize()) {
+                    case 2:
+                        patch.add(new InsnNode(POP2));
+                        break;
+                    case 1:
+                        patch.add(new InsnNode(POP));
+                    case 0:
+                }
+                
                 // }
                 patch.add(new JumpInsnNode(GOTO, continueNode));
                 patch.add(breakNode);


### PR DESCRIPTION
Lambda can have a non-null return value, not removing these values from the stack can end up generating invalid bytecode.

got a forEach with a handle desc that ends with `Z`, this code fixed the bug on a project where I used this code